### PR TITLE
Fix comment editing bug

### DIFF
--- a/api-server/comments.js
+++ b/api-server/comments.js
@@ -111,7 +111,6 @@ function disable (token, id) {
 function edit (token, id, comment) {
     return new Promise((res) => {
         let comments = getData(token)
-        comment = comments[id]
         for (prop in comment) {
             comments[id][prop] = comment[prop]
         }


### PR DESCRIPTION
`comment = comments[id]` was overriding the edited comment passed as a param. We don't need to get the original comment here because even if someone is passing `body` param as `undefined`, body parser will be giving us an empty object which therefore means we will still be returning the original comment back without any changes.