### PR TITLE
Update README.md

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -37,6 +37,6 @@ The following endpoints are available:
 | `GET /posts/:id/comments` | Get all the comments for a single post. | |
 | `POST /comments` | Add a comment to a post. | **id** - Any unique ID. As with posts, UUID is probably the best here. <br> **timestamp** - [Timestamp] Get this however you want. <br> **body** - [String] <br> **author** - [String] <br> **parentId** - Should match a post id in the database. |
 | `GET /comments/:id` | Get the details for a single comment. | |
-| `POST /comments/:id` | Used for voting on a comment. | |
+| `POST /comments/:id` | Used for voting on a comment. | **option** - [String]: Either `"upVote"` or `"downVote"`.  |
 | `PUT /comments/:id` | Edit the details of an existing comment. | **timestamp** - timestamp. Get this however you want. <br> **body** - [String] |
 | `DELETE /comments/:id` | Sets a comment's deleted flag to `true`. | &nbsp; |


### PR DESCRIPTION
The 'POST /comments/:id endpoint requires' requires an 'option' parameter to indicate either 'upVote' or 'downVote'.