### PR TITLE
Fix #22 fetching non-existing post 

### DIFF
--- a/api-server/posts.js
+++ b/api-server/posts.js
@@ -48,7 +48,7 @@ function get (token, id) {
   return new Promise((res) => {
     const posts = getData(token)
     res(
-      posts[id].deleted
+      !posts[id] || posts[id].deleted
         ? {}
         : posts[id]
     )


### PR DESCRIPTION
As intended, getting a non-existing post id will result in empty object instead of a http 500